### PR TITLE
Improve unselected item color and hover state (Chrome)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
 
 **Last.fm Reworked** is a browser extension that enhances the Last.fm layout and user interface. It provides customization options to improve usability and aesthetics, making your experience more enjoyable.
 
-| ![User Profile](https://i.imgur.com/2dc50SK.png) | ![Artist Page](https://i.imgur.com/5Ll8jsB.png) | ![Song Page](https://i.imgur.com/va6qc0h.png) |
+| ![User Profile](https://i.imgur.com/SV6g9NU.jpeg) | ![Artist Page](https://i.imgur.com/TNZyXAS.jpeg) | ![Song Page](https://i.imgur.com/HU7zXh3.jpeg) |
 | :----------------------------------------------: | :---------------------------------------------: | :-------------------------------------------: |
 
 ## Installation
 
 - [Firefox Extension](https://addons.mozilla.org/firefox/addon/last-fm-reworked/)
+- [Chrome Extension](https://chromewebstore.google.com/detail/lastfm-reworked/jihcknccokongmfklnodojmpkjdgihlf)
 
 ## Features
 

--- a/content.css
+++ b/content.css
@@ -496,6 +496,7 @@ select {
 
 .btn-shortcut,
 ul:not(.navlist-items) {
+  background-color: var(--gray-dark) !important;
   border-radius: var(--borda-arredondada) !important;
 }
 
@@ -624,7 +625,7 @@ button.dropdown-menu-clickable-button {
 }
 
 .chartlist-count-bar-value {
-  color: var(--white) !important;
+  color: var(--red-dark) !important;
 }
 
 /* .chartlist-count-bar-link {

--- a/content.css
+++ b/content.css
@@ -522,6 +522,14 @@ button.dropdown-menu-clickable-button {
   border: 0 !important;
 }
 
+.dropdown-menu-clickable-item {
+  color: #999 !important;
+}
+
+.dropdown-menu-clickable-item:hover {
+  color: var(--red) !important;
+}
+
 /* ========== AVATARS & IMAGES ========== */
 .avatar::after {
   border-radius: var(--borda-arredondada) !important;

--- a/content.css
+++ b/content.css
@@ -529,6 +529,7 @@ button.dropdown-menu-clickable-button {
 
 .dropdown-menu-clickable-item:hover {
   color: var(--red) !important;
+  background-color: rgba(186, 0, 0, 0.1) !important;
 }
 
 /* ========== AVATARS & IMAGES ========== */

--- a/content.css
+++ b/content.css
@@ -629,7 +629,7 @@ ul.dropdown-menu-clickable {
 }
 
 .chartlist-count-bar-value {
-  color: var(--black) !important;
+  color: var(--gray-light) !important;
 }
 
 /* .chartlist-count-bar-link {

--- a/content.css
+++ b/content.css
@@ -496,7 +496,6 @@ select {
 
 .btn-shortcut,
 ul:not(.navlist-items) {
-  background-color: var(--gray-dark) !important;
   border-radius: var(--borda-arredondada) !important;
 }
 
@@ -530,6 +529,10 @@ button.dropdown-menu-clickable-button {
 .dropdown-menu-clickable-item:hover {
   color: var(--red) !important;
   background-color: rgba(186, 0, 0, 0.1) !important;
+}
+
+ul.dropdown-menu-clickable {
+  background-color: var(--gray-dark) !important; 
 }
 
 /* ========== AVATARS & IMAGES ========== */
@@ -626,7 +629,7 @@ button.dropdown-menu-clickable-button {
 }
 
 .chartlist-count-bar-value {
-  color: var(--red-dark) !important;
+  color: var(--black) !important;
 }
 
 /* .chartlist-count-bar-link {


### PR DESCRIPTION
### Summary

Improves the styling of the dropdown menu used for time filtering:

- Unselected items now use a softer color (`#999`) for better readability.
- Items now turn red on hover using the CSS variable `--red`, aligning with the visual theme.
- Adds a light red background on hover for .dropdown-menu-clickable-item.
- Adds dark gray background to .btn-shortcut and ul:not(.navlist-items).
- Change count-bar-value color to gray-light.

### Before
- Unselected dropdown items appeared in a very light color, making them hard to distinguish.
- Hover state was not clearly defined.
- Dropdown menu borders were white, causing low contrast with the background.
- The count-bar-value color was set to white, making it difficult to see the scrobbles count.

### After

- Unselected items: `#999`
- Hover: `var(--red)` and background-color `rgba(186, 0, 0, 0.1)`
- Dropdown rounded menu borders now have a gray background
- The new color improves visibility. (We might consider a better color choice in the future.)

amazing work you've done. love it :-)  